### PR TITLE
give user error or info message on console if models folder missing

### DIFF
--- a/index.js
+++ b/index.js
@@ -24,10 +24,10 @@ function init() {
     //check if /model is present or not
     modelDirPath = path.join(process.cwd(), '/models')
     if (!fs.existsSync(modelDirPath)){
-        console.log("Error : models directory not found")
+        console.log("Error : models folder not found, create a models folder to visualize schemas")
         process.exit()
     }
-    
+
     nodeProcess = startProcess();
     watchFiles();
     process.on('SIGINT', async () => { await exitHandler() });

--- a/index.js
+++ b/index.js
@@ -21,6 +21,13 @@ if (process.argv.length === 3) {
 
 // Initialization function
 function init() {
+    //check if /model is present or not
+    modelDirPath = path.join(process.cwd(), '/models')
+    if (!fs.existsSync(modelDirPath)){
+        console.log("Error : models directory not found")
+        process.exit()
+    }
+    
     nodeProcess = startProcess();
     watchFiles();
     process.on('SIGINT', async () => { await exitHandler() });


### PR DESCRIPTION
If models folder is not found it gives user an error message that "models folder not found, create a models folder to visualize schemas" and stops the execution. #56 